### PR TITLE
Changing proxy_set_header Connection from "upgrade" to $connection_up…

### DIFF
--- a/_posts/2015-05-09-setup-rstudio-shiny-server-digital-ocean.md
+++ b/_posts/2015-05-09-setup-rstudio-shiny-server-digital-ocean.md
@@ -336,7 +336,7 @@ map $http_upgrade $connection_upgrade {
 }
 ~~~
 
-Add the following lines **right after** the line that reads `server_name _;`
+And add the following lines **right after** the line that reads `server_name _;`
 
 ~~~
 location /shiny/ {
@@ -354,6 +354,8 @@ location /rstudio/ {
   proxy_set_header Connection $connection_upgrade;
 }
 ~~~
+
+(Note that some of these configuration lines I had to figure out on my own, and I'd like to reiterate that I'm an nginx noob so it might not be a *correct* solution. But it seems to have worked for over 1,000 people for a few years already, so that does give me confidence in these settings!)
 
 Since we changed the nginx config, we need to restart nginx for it to take effect.
 

--- a/_posts/2015-05-09-setup-rstudio-shiny-server-digital-ocean.md
+++ b/_posts/2015-05-09-setup-rstudio-shiny-server-digital-ocean.md
@@ -5,7 +5,7 @@ tags: [professional, rstats, r-bloggers, shiny, tutorial, popular]
 date: 2015-05-09 21:30:00 -0700
 share-img: https://deanattali.com/img/blog/digital-ocean/rstudio.png
 permalink: /2015/05/09/setup-rstudio-shiny-server-digital-ocean/
-lastupdated: 2019-04-10
+lastupdated: 2019-04-11
 carbonads-sm-horizontal: true
 ---
 
@@ -327,7 +327,8 @@ sudo nano /etc/nginx/sites-enabled/default
 
 (I'm assuming you know how to use `nano`. If not, then just Google for "how to edit a file with nano". In short: use the arrow keys to move aroud, press `Ctrl`+`O` followed by Enter to save, and press `Ctrl`+`X` to exit.)
 
-Add the following lines before the line that reads `server {`
+Add the following lines **above** the line that reads `server {`
+
 ~~~
 map $http_upgrade $connection_upgrade {
   default upgrade;
@@ -335,7 +336,7 @@ map $http_upgrade $connection_upgrade {
 }
 ~~~
 
-Add the following lines right after the line that reads `server_name _;`
+Add the following lines **right after** the line that reads `server_name _;`
 
 ~~~
 location /shiny/ {


### PR DESCRIPTION
What do you think about this? I think it would be better for begginers to set the complete config from the start, because debbuging nginx problems with shiny apps could be difficult for begginer because of the absence of error messages in the app's logs.

I´m talking by experience here, I had no idea why my applications weren't working with shiny 1.3.0 without even throwing an error message.